### PR TITLE
Adds more error-handling

### DIFF
--- a/zapi.go
+++ b/zapi.go
@@ -58,6 +58,7 @@ type RequestError struct {
 	Message     string `json:"message,omitempty"`
 	Description string `json:"description,omitempty"`
 	Response    string
+	err         bool `json:"error,omitempty"`
 }
 
 // Error returns the error message.
@@ -256,8 +257,11 @@ func (s *ZapiSession) checkError(resp []byte) error {
 	if err != nil {
 		return fmt.Errorf("%s\n%s", err.Error(), string(resp[:]))
 	}
-
-	reqError.Response = string(resp)
+	if reqError.err {
+		reqError.Response = reqError.Message
+	} else {
+		reqError.Response = string(resp)
+	}
 
 	return reqError
 }


### PR DESCRIPTION
for certain error types (e.g. put on farm), zevenet ce 5 seems to return
a slightly different format to the json error than the current code
expects.  This new handling retains the previous behaviour and works
with the newly-found format.